### PR TITLE
lcg-CA obsoleted by ca-policy-egi-core

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class fetchcrl::params {
     warning('fetchcrl - fetchcrl_capkgs is deprecated, use fetchcrl::capkgs instead')
     $capkgs = $_capkgs
   } else {
-    $capkgs =   ['lcg-CA']
+    $capkgs =   ['ca-policy-egi-core']
   }
   $_carepo        = hiera('fetchcrl_carepo',false)
   if $_carepo {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,8 +18,15 @@ describe 'fetchcrl', type: 'class' do
       { osfamily: 'RedHat',
         operatingsystemmajrelease: '6' }
     end
-    let(:params) { { cache_control_request: '1234' } }
+    let(:params) do
+      {
+        cache_control_request: '1234',
+        capkgs: %w[abc def]
+      }
+    end
 
     it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^cache_control_request = 1234$}) }
+    it { is_expected.to contain_package('abc').with_ensure('present') }
+    it { is_expected.to contain_package('def').with_ensure('present') }
   end
 end


### PR DESCRIPTION
Technically lcg-CA is now obsoleted by ca-policy-egi-core
so moving to that. Seems to actucally be the same CA set
so not imediatly worried anyway.

There are some details here:

* https://wiki.egi.eu/wiki/EGI_IGTF_Release
* http://repository.egi.eu/sw/production/cas/1/current/README.txt

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
