### PR TITLE
added noerrors to config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ class fetchcrl::config (
   $agingtolerance        = $fetchcrl::agingtolerance,
   $nosymlinks            = $fetchcrl::nosymlinks,
   $nowarnings            = $fetchcrl::nowarnings,
+  $noerrors              = $fetchcrl::noerrors,
   $http_proxy            = $fetchcrl::http_proxy,
   $httptimeout           = $fetchcrl::httptimeout,
   $parallelism           = $fetchcrl::parallelism,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class fetchcrl (
   $agingtolerance = $fetchcrl::params::agingtolerance,
   $nosymlinks = $fetchcrl::params::nosymlinks,
   $nowarnings  = $fetchcrl::params::nowarnings,
+  $noerrors  = $fetchcrl::params::noerrors,
   $http_proxy = $fetchcrl::params::http_proxy,
   $httptimeout = $fetchcrl::params::httptimeout,
   $parallelism = $fetchcrl::params::parallelism,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class fetchcrl::params {
   $agingtolerance = 24
   $nosymlinks     = true
   $nowarnings     = true
+  $noerrors       = true
   $_http_proxy    = hiera('fetchcrl_proxy',false)
   if $_http_proxy {
     warning('fetchcrl - hiera var fetchcrl_proxy is deprecated, use fetchcrl::proxy instead')

--- a/templates/fetch-crl-anchor.conf.erb
+++ b/templates/fetch-crl-anchor.conf.erb
@@ -7,6 +7,9 @@ agingtolerance = <%= @agingtollerance %>
 <% if @nowarnings -%>
 nowarnings
 <% end -%>
+<% if @noerrors -%>
+noerrors
+<% end -%>
 <% if @httptimeout -%>
 httptimeout = <%= @httptimeout %>
 <% end -%>

--- a/templates/fetch-crl.conf.erb
+++ b/templates/fetch-crl.conf.erb
@@ -9,6 +9,9 @@ nosymlinks
 <% if @nowarnings -%>
 nowarnings
 <% end -%>
+<% if @noerrors -%>
+noerrors
+<% end -%>
 <% if @http_proxy -%>
 http_proxy = <%= @http_proxy %>
 <% end -%>


### PR DESCRIPTION

#### Pull Request (PR) description

Adding `noerrors` option to the configuration file.
`fetchcrl::noerrors` variable can change this behavior.

#### This Pull Request (PR) fixes the following issues
Fixes #43

