### PR TITLE
New randomcron parameter, random offset of cron

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,10 @@
+---
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      puppet_version: ">= 6.0.0"
+    augeas_core:
+      repo: https://github.com/puppetlabs/puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class fetchcrl::config (
   $http_proxy            = $fetchcrl::http_proxy,
   $httptimeout           = $fetchcrl::httptimeout,
   $parallelism           = $fetchcrl::parallelism,
+  $randomcron            = $fetchcrl::randomcron,
   $logmode               = $fetchcrl::logmode,
   $pkgname               = $fetchcrl::pkgname,
   $cache_control_request = $fetchcrl::cache_control_request,
@@ -46,4 +47,18 @@ class fetchcrl::config (
     recurse => true,
   }
 
+  # Set 6 hour interval cron to have a random offset.
+  if $randomcron {
+    $_hour = "${fqdn_rand(6,'fetchcrl')}-23/6"
+    $_minute  = fqdn_rand(60,'fetchcrl')
+    augeas{'randomise_cron':
+      incl    => '/etc/cron.d/fetch-crl',
+      lens    => 'Cron.lns',
+      context => '/files/etc/cron.d/fetch-crl/entry/time',
+      changes => [
+        "set minute ${_minute}",
+        "set hour ${_hour}",
+      ],
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,9 @@
 # @param runcron
 #  Should fetch-crl be run as a cron job.
 #
+# @param randomcron
+#  Should the every 6 hour cron be configured with a random offset.
+#
 # @param cache_control_request
 #  sends a cache-control max-age hint in seconds towards the server in the HTTP request.
 #
@@ -72,6 +75,7 @@ class fetchcrl (
   Boolean $nosymlinks                      = true,
   Boolean $nowarnings                      = true,
   Boolean $noerrors                        = false,
+  Boolean $randomcron                      = true,
   Optional[Stdlib::Httpurl] $http_proxy    = undef,
   Integer $httptimeout                     = 30,
   Integer $parallelism                     = 4,

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -1,16 +1,19 @@
 require 'spec_helper_acceptance'
 
 describe 'fetchcrl' do
-  it 'configures and work with no errors' do
-    pp = <<-EOS
-      class{'fetchcrl':
-      }
-    EOS
-    apply_manifest(pp, catch_failures: true)
-    apply_manifest(pp, catch_changes: true)
-    # We accept 1 as a return code also since there will be some failing CAs
-    # out there in the wild.
-    shell('fetch-crl', acceptable_exit_codes: [0, 1])
-    shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
+  context 'with fetchcrl' do
+    let(:pp) { 'class{"fetchcrl": }' }
+
+    it 'configures and work with no errors' do
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+      # We accept 1 as a return code also since there will be some failing CAs
+      # out there in the wild.
+      shell('fetch-crl', acceptable_exit_codes: [0, 1])
+      shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
+    end
+    describe file('/etc/cron.d/fetch-crl') do
+      its(:content) { is_expected.to match %r{^([0-9]|[1-5][0-9]) [0-5]-23/6 \* \* \*.*$} }
+    end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,6 +14,8 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_package('fetch-crl') }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{cache_control_request}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{noerrors}) }
+        it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
+        it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
       end
       context 'with all parameters set' do
         let(:params) do
@@ -27,14 +29,28 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_package('abc').with_ensure('present') }
         it { is_expected.to contain_package('def').with_ensure('present') }
       end
-      context 'with noerrors parameters set' do
+      context 'with boolean params parameters set true' do
         let(:params) do
           {
-            noerrors: true
+            noerrors: true,
+            randomcron: true
           }
         end
 
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^noerrors$}) }
+        it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
+        it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
+      end
+      context 'with boolean params parameters set false' do
+        let(:params) do
+          {
+            noerrors: false,
+            randomcron: false
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{^noerrors$}) }
+        it { is_expected.not_to contain_augeas('randomise_cron') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

The fetch-crl cron runs at 06,12,18,24 hours.

This patch randomises (with fqdn_rand)  the offset
of the 6 hour intervals. The minutes are also randomised.