### PR TITLE
Addition of RedHat 8 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    systemd: 'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,7 +48,7 @@ class fetchcrl::config (
   }
 
   # Set 6 hour interval cron to have a random offset.
-  if $randomcron {
+  if $fetchcrl::periodic_method == 'cron' and $randomcron {
     $_hour = "${fqdn_rand(6,'fetchcrl')}-23/6"
     $_minute  = fqdn_rand(60,'fetchcrl')
     augeas{'randomise_cron':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,8 +59,15 @@
 # @param runcron
 #  Should fetch-crl be run as a cron job.
 #
+# @param runboot
+#  Should fetch-crl be run at boot time.
+#  This parameter is only significant for fetch-crl packages
+#  that do not use a cron based package and not a systemd timer.
+#
 # @param randomcron
 #  Should the every 6 hour cron be configured with a random offset.
+#  With osfamily RedHat 8 or newer the randomcron parameter is ignored.
+#  The systemd timer for fetch-crl is already very random.
 #
 # @param cache_control_request
 #  sends a cache-control max-age hint in seconds towards the server in the HTTP request.
@@ -86,6 +93,13 @@ class fetchcrl (
   Boolean $runcron                         = true,
   Optional[Integer] $cache_control_request = undef,
 ) {
+
+  # Is the package cron or systemd.timer based?
+  $periodic_method = $facts['os']['release']['major'] ? {
+    '6' => 'cron',
+    '7' => 'cron',
+    default => 'timer',
+  }
 
   contain 'fetchcrl::install'
   contain 'fetchcrl::config'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,16 +11,27 @@ class fetchcrl::service (
 
   assert_private()
 
-  service { "${pkgname}-boot":
-    ensure     => $runboot,
-    enable     => $runboot,
-    hasstatus  => true,
-    hasrestart => true,
-  }
-  service { "${pkgname}-cron":
-    ensure     => $runcron,
-    enable     => $runcron,
-    hasstatus  => true,
-    hasrestart => true,
+  case $fetchcrl::periodic_method {
+    'cron': {
+      service { "${pkgname}-boot":
+        ensure     => $runboot,
+        enable     => $runboot,
+        hasstatus  => true,
+        hasrestart => true,
+      }
+      service { "${pkgname}-cron":
+        ensure     => $runcron,
+        enable     => $runcron,
+        hasstatus  => true,
+        hasrestart => true,
+      }
+    }
+    'timer': {
+      service{"${pkgname}.timer":
+        ensure => $runcron,
+        enable => $runcron,
+      }
+    }
+    default: { fail('periodic_method not cron or timer?') }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -30,14 +30,16 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     }
   ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,6 @@ describe 'fetchcrl', type: 'class' do
           it { is_expected.to contain_service('fetch-crl-boot').with_enable(false) }
           it { is_expected.to contain_service('fetch-crl-cron').with_ensure(true) }
           it { is_expected.to contain_service('fetch-crl-cron').with_enable(true) }
-          it { is_expected.to have_systemd__dropin_resource_count(0) }
         else
           it { is_expected.not_to contain_augeas('randomise_cron') }
           it { is_expected.not_to contain_service('fetch-crl-boot') }
@@ -62,7 +61,6 @@ describe 'fetchcrl', type: 'class' do
           it { is_expected.to contain_service('fetch-crl-boot').with_enable(true) }
           it { is_expected.to contain_service('fetch-crl-cron').with_ensure(true) }
           it { is_expected.to contain_service('fetch-crl-cron').with_enable(true) }
-          it { is_expected.to have_systemd__dropin_resource_count(0) }
           it { is_expected.not_to contain_service('fetch-crl.timer') }
         else
           it { is_expected.not_to contain_augeas('randomise_cron') }
@@ -84,7 +82,6 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.not_to contain_augeas('randomise_cron') }
         case facts[:os]['release']['major']
         when '6', '7'
-          it { is_expected.to have_systemd__dropin_resource_count(0) }
           it { is_expected.not_to contain_service('fetch-crl.timer') }
         else
           it { is_expected.to contain_service('fetch-crl.timer').with_ensure(false) }


### PR DESCRIPTION
#### Pull Request (PR) description
The fetch-crl package in RedHat family 8 uses systemd timers
rather than cron jobs.

This module now configures and controls those systemd timers
rather than cron jobs on RedHat family 8.

The `randomcron` parameter is completely ignored for RedHat
family 8 since the timer from the package is already quite
random.

The `atboot` parameter is completely ignored for RedHat
family 8 as the systemd timer is better configured with systemd drop in file outside
this module.

#### This Pull Request (PR) fixes the following issues
