### PR TITLE
Remove fictitious runatboot from docs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,9 +53,6 @@
 # @param pkgname
 #  Name of fetch-crl package.
 #
-# @param runatboot
-#  Should fetch-crl be ran at boot time.
-#
 # @param runcron
 #  Should fetch-crl be run as a cron job.
 #


### PR DESCRIPTION
Both runatboot and runboot parameters were documented. Only
runboot is a real parameter.

