### PR TITLE
Give examples headings

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -1,7 +1,7 @@
 # @summary
 #  Creates per CA configuration files.
 #
-# @example
+# @example Simple Example
 #  fetchcrl::ca{'EDG-Tutorial-CA':
 #    agingtolerance => 168
 #  }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #  Main class, installs fetch-crl and configured it.
 #  https://wiki.nikhef.nl/grid/FetchCRL3
 #
-# @example
+# @example Simple Example
 #  class{'fetchcrl':
 #    http_proxy            => 'http:://squid.example.org:8000',
 #    carepo                => 'http://yum.example.org/yumrepo',


### PR DESCRIPTION
#### Pull Request (PR) description

Giving names to examples avoids empty headers being
generated in the generated strings docs.