### PR TITLE
Enable acceptance tests for CentOS 8

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -4,3 +4,4 @@
    docker_sets:
       - set: centos6-64
       - set: centos7-64
+      - set: centos8-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ matrix:
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -13,7 +13,12 @@ describe 'fetchcrl' do
       shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
     end
     describe file('/etc/cron.d/fetch-crl') do
-      its(:content) { is_expected.to match %r{^([0-9]|[1-5][0-9]) [0-5]-23/6 \* \* \*.*$} }
+      case fact('operatingsystemmajrelease')
+      when '6', '7'
+        its(:content) { is_expected.to match %r{^([0-9]|[1-5][0-9]) [0-5]-23/6 \* \* \*.*$} }
+      else
+        it { is_expected.not_to exist }
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Enable acceptance tests for CentOS 8

The acceptance tests are updated to reflect that with C8 fetch-crl uses a systemd timer rather than
a cron job. 

