### PR TITLE
Add inet6glue flag configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 class fetchcrl::config (
   $agingtolerance        = $fetchcrl::agingtolerance,
   $nosymlinks            = $fetchcrl::nosymlinks,
+  $inet6glue             = $fetchcrl::inet6glue,
   $nowarnings            = $fetchcrl::nowarnings,
   $noerrors              = $fetchcrl::noerrors,
   $http_proxy            = $fetchcrl::http_proxy,
@@ -22,6 +23,7 @@ class fetchcrl::config (
     content => epp('fetchcrl/fetch-crl.conf.epp',{
         'agingtolerance'        => $agingtolerance,
         'nosymlinks'            => $nosymlinks,
+        'inet6glue'             => $inet6glue,
         'nowarnings'            => $nowarnings,
         'noerrors'              => $noerrors,
         'http_proxy'            => $http_proxy,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 # @param nosymlinks
 #  do not create serial number symlinks.
 #
+# @param inet6glue
+#  use Net::INET6Glue
+#
 # @param noerrors
 #  do not produce errors.
 #
@@ -81,6 +84,7 @@ class fetchcrl (
   String $pkg_version                      = 'present',
   Integer $agingtolerance                  = 24,
   Boolean $nosymlinks                      = true,
+  Boolean $inet6glue                       = false,
   Boolean $nowarnings                      = true,
   Boolean $noerrors                        = false,
   Boolean $randomcron                      = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,11 +10,24 @@ class fetchcrl::install (
   $carepo_gpgkey  = $fetchcrl::carepo_gpgkey,
   $manage_carepo  = $fetchcrl::manage_carepo,
   $capkgs_version = $fetchcrl::capkgs_version,
-  $pkg_version    = $fetchcrl::pkg_version
+  $pkg_version    = $fetchcrl::pkg_version,
+  $inet6glue      = $fetchcrl::inet6glue
 ) {
   assert_private()
 
   # The fetch-crl package.
+  if $inet6glue {
+    $inet6glue_pkg = $facts['os']['family'] ? {
+      'Debian' => 'libnet-inet6glue-perl',
+      'RedHat' => 'perl-Net-INET6Glue',
+    }
+
+    package { $inet6glue_pkg:
+      ensure => 'present',
+      before => Package[$pkgname],
+    }
+  }
+
   package { $pkgname:
     ensure => $pkg_version,
   }

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -21,4 +21,14 @@ describe 'fetchcrl' do
       end
     end
   end
+  context 'with fetchcrl and ipv6' do
+    let(:pp) { 'class{"fetchcrl": inet6glue => true }' }
+
+    it 'configures and work with no errors' do
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+      shell('fetch-crl', acceptable_exit_codes: [0, 1])
+      shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
+    end
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,6 +14,7 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_package('fetch-crl') }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{cache_control_request}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{noerrors}) }
+        it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{inet6glue}) }
         case facts[:os]['family']
         when 'Debian'
           it {
@@ -94,16 +95,20 @@ describe 'fetchcrl', type: 'class' do
             runcron: true,
             runboot: true,
             manage_carepo: true,
+            inet6glue: true,
           }
         end
 
         case facts[:os]['family']
         when 'Debian'
           it { is_expected.to contain_apt__source('carepo') }
+          it { is_expected.to contain_package('libnet-inet6glue-perl').with_ensure('present')}
         else
           it { is_expected.to contain_yumrepo('carepo') }
+          it { is_expected.to contain_package('perl-Net-INET6Glue').with_ensure('present')}
         end
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^noerrors$}) }
+        it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^inet6glue$}) }
         case [facts[:os]['name'], facts[:os]['release']['major']]
         when %w[RedHat 7], %w[CentOS 7], %w[Debian 10], ['Ubuntu', '18.04']
           it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }

--- a/templates/fetch-crl.conf.epp
+++ b/templates/fetch-crl.conf.epp
@@ -1,6 +1,7 @@
 <% |
   Integer $agingtolerance,
   Boolean $nosymlinks,
+  Boolean $inet6glue,
   Boolean $nowarnings,
   Boolean $noerrors,
   Optional[Stdlib::Httpurl] $http_proxy = undef,
@@ -16,6 +17,9 @@ agingtolerance = <%= $agingtolerance %>
 <% } -%>
 <% if $nosymlinks { -%>
 nosymlinks
+<% } -%>
+<% if $inet6glue { -%>
+inet6glue
 <% } -%>
 <% if $nowarnings { -%>
 nowarnings


### PR DESCRIPTION
#### Pull Request (PR) description

Add ability to configure `inet6glue`. This flag is required to prefer IPv6 over IPv4 when configuring fetch-crl with dual-stack proxies.

#### This Pull Request (PR) fixes the following issues

None, new feature.
