### PR TITLE
Drop Puppet 5 and CentOS 6 Support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,5 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
-      puppet_version: ">= 6.0.0"
-    augeas_core:
-      repo: https://github.com/puppetlabs/puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core.git'
+    augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core.git'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,6 @@ class fetchcrl (
 ) {
   # Is the package cron or systemd.timer based?
   $periodic_method = $facts['os']['release']['major'] ? {
-    '6' => 'cron',
     '7' => 'cron',
     default => 'timer',
   }

--- a/metadata.json
+++ b/metadata.json
@@ -16,20 +16,19 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -37,7 +36,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -15,7 +15,7 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{cache_control_request}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{noerrors}) }
         case facts[:os]['release']['major']
-        when '6', '7'
+        when '7'
           it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
           it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
           it { is_expected.to contain_service('fetch-crl-boot').with_ensure(false) }
@@ -54,7 +54,7 @@ describe 'fetchcrl', type: 'class' do
 
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^noerrors$}) }
         case facts[:os]['release']['major']
-        when '6', '7'
+        when '7'
           it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
           it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
           it { is_expected.to contain_service('fetch-crl-boot').with_ensure(true) }
@@ -81,7 +81,7 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{^noerrors$}) }
         it { is_expected.not_to contain_augeas('randomise_cron') }
         case facts[:os]['release']['major']
-        when '6', '7'
+        when '7'
           it { is_expected.not_to contain_service('fetch-crl.timer') }
         else
           it { is_expected.to contain_service('fetch-crl.timer').with_ensure(false) }


### PR DESCRIPTION
#### Pull Request (PR) description
* Drop Puppet 5 support
* Drop CentOS 6 support
* Add Puppet 7 support
* Increase upper bound of puppetlabs-stdlib
