### PR TITLE
Support hash of fetchcrl::ca as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Two custom facts are included.
 *trustedca*  returns an array of all the certificate authoriry subjects located
 at /etc/grid-security/*.pem
 
+## Refernce
+See [REFERENCE.md](https://github.com/voxpupuli/puppet-fetchcrl/blob/master/REFERENCE.md) for more details
+
 ## License
 
 Apache-2.0

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,6 +47,7 @@ The following parameters are available in the `fetchcrl` class:
 * [`runboot`](#runboot)
 * [`randomcron`](#randomcron)
 * [`cache_control_request`](#cache_control_request)
+* [`cas`](#cas)
 * [`capkgs`](#capkgs)
 * [`carepo`](#carepo)
 * [`carepo_gpgkey`](#carepo_gpgkey)
@@ -188,6 +189,14 @@ Default value: ``true``
 Data type: `Optional[Integer]`
 
 Sends a cache-control max-age hint in seconds towards the server in the HTTP request.
+
+Default value: ``undef``
+
+##### <a name="cas"></a>`cas`
+
+Data type: `Optional[Hash]`
+
+A hash of `fetchcrl::ca` defined types to load.
 
 Default value: ``undef``
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class fetchcrl::config (
   $logmode               = $fetchcrl::logmode,
   $pkgname               = $fetchcrl::pkgname,
   $cache_control_request = $fetchcrl::cache_control_request,
+  $cas                   = $fetchcrl::cas,
 ) {
   assert_private()
 
@@ -60,6 +61,14 @@ class fetchcrl::config (
         "set minute ${_minute}",
         "set hour ${_hour}",
       ],
+    }
+  }
+
+  if $cas {
+    $cas.each |$_name, $_config| {
+      fetchcrl::ca { $_name:
+        * => $_config,
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,19 @@
 #    cache_control_request => '3600',
 #  }
 #
+# @example A hash of particular CA configurations
+#  class{'fetchcrl':
+#    cas => {
+#      'EDG-Tutorial-CA' => {
+#        'agingtolerance' => 168,
+#       }
+#       'MD-Grid-CA-T'   => {
+#        'noerrors'       => true,
+#       }
+#      }
+#    }
+#  }
+#
 # @param capkgs
 #  CA policy packages to install.
 #
@@ -77,6 +90,9 @@
 # @param cache_control_request
 #  Sends a cache-control max-age hint in seconds towards the server in the HTTP request.
 #
+# @param cas
+#  A hash of `fetchcrl::ca` defined types to load.
+#
 class fetchcrl (
   Array[String[1]] $capkgs                 = ['ca-policy-egi-core'],
   Stdlib::Httpurl $carepo                  = 'https://repository.egi.eu/sw/production/cas/1/current/',
@@ -98,6 +114,7 @@ class fetchcrl (
   Boolean $runboot                         = false,
   Boolean $runcron                         = true,
   Optional[Integer] $cache_control_request = undef,
+  Optional[Hash] $cas                      = undef,
 ) {
   # Is the package cron or systemd.timer based?
   if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'18.04') <= 0 ) or

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -21,13 +21,28 @@ describe 'fetchcrl' do
       end
     end
   end
-  context 'with fetchcrl and ipv6' do
-    let(:pp) { 'class{"fetchcrl": inet6glue => true }' }
+  context 'with fetchcrl and ipv6 and cas' do
+    let(:pp) do
+      '
+               class{"fetchcrl":
+                 inet6glue => true,
+                 cas => {
+                   "EDG" => { "noerrors" => true },
+                   "MD"  => {
+                      "anchorname" => "MyMD",
+                      "agingtolerance" => 125,
+                   },
+                 }
+               }
+               '
+    end
 
     it 'configures and work with no errors' do
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
       shell('fetch-crl', acceptable_exit_codes: [0, 1])
+      shell('ls /etc/fetch-crl.d/EDG.conf', acceptable_exit_codes: 0)
+      shell('ls /etc/fetch-crl.d/MyMD.conf', acceptable_exit_codes: 0)
       shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -15,6 +15,7 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{cache_control_request}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{noerrors}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{inet6glue}) }
+        it { is_expected.to have_fetchcrl__ca_resource_count(0) }
         case facts[:os]['family']
         when 'Debian'
           it {
@@ -60,12 +61,22 @@ describe 'fetchcrl', type: 'class' do
             capkgs: %w[abc def],
             carepo: 'https://example.org/foo',
             carepo_gpgkey: 'https://example.org/foo.gpg',
+            cas: {
+              'EDG' => {
+                'agingtolerance' => 168,
+              },
+              'MD' => {
+                'noerrors' => true,
+              }
+            }
           }
         end
 
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^cache_control_request = 1234$}) }
         it { is_expected.to contain_package('abc').with_ensure('present') }
         it { is_expected.to contain_package('def').with_ensure('present') }
+        it { is_expected.to contain_fetchcrl__ca('EDG').with_agingtolerance(168) }
+        it { is_expected.to contain_fetchcrl__ca('MD').with_noerrors(true) }
         case facts[:os]['family']
         when 'Debian'
           it {
@@ -102,10 +113,10 @@ describe 'fetchcrl', type: 'class' do
         case facts[:os]['family']
         when 'Debian'
           it { is_expected.to contain_apt__source('carepo') }
-          it { is_expected.to contain_package('libnet-inet6glue-perl').with_ensure('present')}
+          it { is_expected.to contain_package('libnet-inet6glue-perl').with_ensure('present') }
         else
           it { is_expected.to contain_yumrepo('carepo') }
-          it { is_expected.to contain_package('perl-Net-INET6Glue').with_ensure('present')}
+          it { is_expected.to contain_package('perl-Net-INET6Glue').with_ensure('present') }
         end
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^noerrors$}) }
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^inet6glue$}) }


### PR DESCRIPTION
#### Pull Request (PR) description
The main class now supports a hash of `fetchcrl::ca` types

e.g.

```puppet
class{'fetchcrl':
  cas => {
    'MD' => {
      'noerrors' => true,
    },
    'EDG' => {
      'ageingtolerance' => 33,
    }
  }
```
