### PR TITLE
New comment parameter to fetch-crl::ca type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ class{'fetchcrl':
 }
 
 fetchcrl::ca{'EDG-Tutorial-CA':
- agingtolerance => 168
+ agingtolerance => 168,
+ comment        => 'Increased as unreliable',
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -236,7 +236,8 @@ Creates per CA configuration files.
 
 ```puppet
 fetchcrl::ca{'EDG-Tutorial-CA':
-  agingtolerance => 168
+  agingtolerance => 168,
+  comment        => 'Increased as unreliable',
 }
 ```
 
@@ -250,6 +251,7 @@ The following parameters are available in the `fetchcrl::ca` defined type:
 * [`noerrors`](#noerrors)
 * [`httptimeout`](#httptimeout)
 * [`agingtolerance`](#agingtolerance)
+* [`comment`](#comment)
 * [`crl_url`](#crl_url)
 
 ##### <a name="name"></a>`name`
@@ -293,6 +295,14 @@ Default value: ``undef``
 Data type: `Optional[Integer]`
 
 The delay if failures before it is considered an error.
+
+Default value: ``undef``
+
+##### <a name="comment"></a>`comment`
+
+Data type: `Optional[String[1]]`
+
+Add a comment to the particular CA configuration
 
 Default value: ``undef``
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -3,7 +3,8 @@
 #
 # @example Simple Example
 #  fetchcrl::ca{'EDG-Tutorial-CA':
-#    agingtolerance => 168
+#    agingtolerance => 168,
+#    comment        => 'Increased as unreliable',
 #  }
 #
 # @param name
@@ -24,6 +25,9 @@
 # @param agingtolerance
 #  The delay if failures before it is considered an error.
 #
+# @param comment
+#  Add a comment to the particular CA configuration
+#
 # @param crl_url
 #  A list of URLs to download CAs from
 #
@@ -33,6 +37,7 @@ define fetchcrl::ca (
   Boolean $noerrors                 = false,
   Optional[Integer] $httptimeout    = undef,
   Optional[Integer] $agingtolerance = undef,
+  Optional[String[1]] $comment      = undef,
   Array[Stdlib::Httpurl] $crl_url   = [],
 ) {
   include 'fetchcrl'
@@ -42,13 +47,14 @@ define fetchcrl::ca (
     mode    => '0644',
     owner   => root,
     group   => root,
-    content => epp('fetchcrl/fetch-crl-anchor.conf.epp',{
+    content => epp('fetchcrl/fetch-crl-anchor.conf.epp', {
         'anchorname'     => $anchorname,
         'agingtolerance' => $agingtolerance,
         'nowarnings'     => $nowarnings,
         'noerrors'       => $noerrors,
         'httptimeout'    => $httptimeout,
         'crl_url'        => $crl_url,
+        'comment'        => $comment,
     }),
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,7 +21,7 @@ class fetchcrl::config (
 
   file { "/etc/${pkgname}.conf":
     ensure  => file,
-    content => epp('fetchcrl/fetch-crl.conf.epp',{
+    content => epp('fetchcrl/fetch-crl.conf.epp', {
         'agingtolerance'        => $agingtolerance,
         'nosymlinks'            => $nosymlinks,
         'inet6glue'             => $inet6glue,

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -37,6 +37,7 @@ describe 'fetchcrl' do
                    "MD"  => {
                       "anchorname" => "MyMD",
                       "agingtolerance" => 125,
+                      "comment" => "My Comment",
                    },
                  }
                }

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -52,6 +52,7 @@ describe 'fetchcrl::ca' do
         let(:params) do
           {
             nowarnings: true,
+            comment: 'My Comment',
             noerrors: true,
             httptimeout: 1234,
             agingtolerance: 9876,
@@ -60,6 +61,7 @@ describe 'fetchcrl::ca' do
         end
 
         it { is_expected.to contain_file('/etc/foo.d/myinstance.conf').with_content(%r{^nowarnings$}) }
+        it { is_expected.to contain_file('/etc/foo.d/myinstance.conf').with_content(%r{^# My Comment$}) }
         it { is_expected.to contain_file('/etc/foo.d/myinstance.conf').with_content(%r{^noerrors$}) }
         it { is_expected.to contain_file('/etc/foo.d/myinstance.conf').with_content(%r{^agingtolerance = 9876$}) }
         it { is_expected.to contain_file('/etc/foo.d/myinstance.conf').with_content(%r{^httptimeout = 1234$}) }

--- a/templates/fetch-crl-anchor.conf.epp
+++ b/templates/fetch-crl-anchor.conf.epp
@@ -5,9 +5,14 @@
   Boolean $noerrors,
   Optional[Integer] $httptimeout = undef,
   Array[Stdlib::Httpurl] $crl_url,
+  Optional[String] $comment = undef,
 | -%>
 # <%= $anchorname -%>.conf file installed with puppet.
 
+<% if $comment { -%>
+# <%= $comment %>
+
+<% } -%>
 [<%= $anchorname -%>]
 <% if $agingtolerance { -%>
 agingtolerance = <%= $agingtolerance %>


### PR DESCRIPTION
#### Pull Request (PR) description
An optional comment can now be added to each per CA configuration.

e.g.

```puppet
fetch-crl::ca{'EDG':
   noerrors => true,
   comment  => 'Ignore since it always fails',
}
```

This will add a comment to the resulting `/etc/fetch-crl.d/EDG.conf` file.

#### This Pull Request (PR) fixes the following issues

