### PR TITLE
GPG key update EUGridPMA-RPM v3 to v4r1

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -106,7 +106,7 @@ Data type: `Stdlib::Httpurl`
 
 Repository URL of GPG key for CA packages.
 
-Default value: `'https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3'`
+Default value: `'https://repository.egi.eu/sw/production/cas/1/current/GPG-KEY-EUGridPMA-RPM-4R1'`
 
 ##### <a name="-fetchcrl--manage_carepo"></a>`manage_carepo`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@
 class fetchcrl (
   Array[String[1]] $capkgs                 = ['ca-policy-egi-core'],
   Stdlib::Httpurl $carepo                  = 'https://repository.egi.eu/sw/production/cas/1/current/',
-  Stdlib::Httpurl $carepo_gpgkey           = 'https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3',
+  Stdlib::Httpurl $carepo_gpgkey           = 'https://repository.egi.eu/sw/production/cas/1/current/GPG-KEY-EUGridPMA-RPM-4R1',
   Boolean $manage_carepo                   = true,
   String $capkgs_version                   = 'present',
   String $pkg_version                      = 'present',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,7 +57,7 @@ class fetchcrl::install (
           location      => $carepo,
           key           => {
             ensure => refreshed,
-            id     => 'D12E922822BE64D50146188BC32D99C83CDBBC71',
+            id     => '565F4528EAD3F53727B5A2E9B055005676341F1A',
             source => $carepo_gpgkey,
           },
           release       => 'egi-igtf',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,7 +25,7 @@ describe 'fetchcrl', type: 'class' do
             expect(subject).to contain_apt__source('carepo').with(
               {
                 location: 'https://repository.egi.eu/sw/production/cas/1/current/',
-                key: { 'ensure' => 'refreshed', 'id' => 'D12E922822BE64D50146188BC32D99C83CDBBC71', 'source' => 'https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3' },
+                key: { 'ensure' => 'refreshed', 'id' => '565F4528EAD3F53727B5A2E9B055005676341F1A', 'source' => 'https://repository.egi.eu/sw/production/cas/1/current/GPG-KEY-EUGridPMA-RPM-4R1' },
               }
             )
           }
@@ -36,7 +36,7 @@ describe 'fetchcrl', type: 'class' do
             expect(subject).to contain_yumrepo('carepo').with(
               {
                 baseurl: 'https://repository.egi.eu/sw/production/cas/1/current/',
-                gpgkey: 'https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3',
+                gpgkey: 'https://repository.egi.eu/sw/production/cas/1/current/GPG-KEY-EUGridPMA-RPM-4R1',
               }
             )
           }
@@ -90,7 +90,7 @@ describe 'fetchcrl', type: 'class' do
             expect(subject).to contain_apt__source('carepo').with(
               {
                 location: 'https://example.org/foo',
-                key: { 'ensure' => 'refreshed', 'id' => 'D12E922822BE64D50146188BC32D99C83CDBBC71', 'source' => 'https://example.org/foo.gpg' },
+                key: { 'ensure' => 'refreshed', 'id' => '565F4528EAD3F53727B5A2E9B055005676341F1A', 'source' => 'https://example.org/foo.gpg' },
               }
             )
           }


### PR DESCRIPTION
#### Pull Request (PR) description

As par the registration required link:

https://operations-portal.egi.eu/broadcast/archive/3091

```
Changes from 1.134 to 1.135
---------------------------
(5 May 2025)

* Updated SlovakGrid trust anchor with extended validity (SK)
* Withdrawn discontinued HPCI CA (JP)

NOTE: the _default_ package signing key has changed to the 4th
generation
for increased security and compatibility. The new key is a 2048 bit
RSA with fingerprint 565F4528EAD3F53727B5A2E9B055005676341F1A.
The GPG public key file can be retrieved from
https://dl.igtf.net/distribution/current/GPG-KEY-EUGridPMA-RPM-4
and imported on rpm-based distributions with 'rpmkeys --import '
or on Debian (apt) based systems set in Signed-By in sources.list or
added as a file in /etc/apt/trusted.gpg.d/

This change was first announced in the 1.122 release (August 2023),
but a distribution signed with the generation-3 key remains available.
A signature of the gen-4 key signed by the gen-3 GPG key is available
from
https://egi-igtf.ndpf.info/distribution/egi/current/GPG-KEY-EUGridPMA-RPM-4
for validation.
```


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
