### PR TITLE
Drop EOL Ubuntu 20.04 CentOS 7, 8 and RHEL 7

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -79,7 +79,6 @@ The following parameters are available in the `fetchcrl` class:
 * [`logmode`](#-fetchcrl--logmode)
 * [`pkgname`](#-fetchcrl--pkgname)
 * [`runcron`](#-fetchcrl--runcron)
-* [`runboot`](#-fetchcrl--runboot)
 * [`randomcron`](#-fetchcrl--randomcron)
 * [`cache_control_request`](#-fetchcrl--cache_control_request)
 * [`cas`](#-fetchcrl--cas)
@@ -219,16 +218,6 @@ Data type: `Boolean`
 Should fetch-crl be run periodically either as a cron job or timer as appropriate.
 
 Default value: `true`
-
-##### <a name="-fetchcrl--runboot"></a>`runboot`
-
-Data type: `Boolean`
-
-Should fetch-crl be run at boot time.
-This parameter is only significant for fetch-crl packages
-that use a cron based package and not a systemd timer.
-
-Default value: `false`
 
 ##### <a name="-fetchcrl--randomcron"></a>`randomcron`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,21 +56,6 @@ class fetchcrl::config (
     recurse => true,
   }
 
-  # Set 6 hour interval cron to have a random offset.
-  if $fetchcrl::periodic_method == 'cron' and $randomcron {
-    $_hour = "${fqdn_rand(6,'fetchcrl')}-23/6"
-    $_minute  = fqdn_rand(60,'fetchcrl')
-    augeas { 'randomise_cron':
-      incl    => '/etc/cron.d/fetch-crl',
-      lens    => 'Cron.lns',
-      context => '/files/etc/cron.d/fetch-crl/entry/time',
-      changes => [
-        "set minute ${_minute}",
-        "set hour ${_hour}",
-      ],
-    }
-  }
-
   if $cas {
     $cas.each |$_name, $_config| {
       fetchcrl::ca { $_name:
@@ -79,9 +64,9 @@ class fetchcrl::config (
     }
   }
 
-  #Ubuntu 20.04 package has the timer add but cron jobs are still present.
+  # Debian, Ubuntu package has the timer add but cron jobs are still present.
   # https://bugs.launchpad.net/ubuntu/+source/fetch-crl/+bug/1920742
-  if $fetchcrl::periodic_method == 'timer' and $facts['os']['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     file { '/etc/cron.d/fetch-crl':
       ensure => absent,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,11 +77,6 @@
 # @param runcron
 #  Should fetch-crl be run periodically either as a cron job or timer as appropriate.
 #
-# @param runboot
-#  Should fetch-crl be run at boot time.
-#  This parameter is only significant for fetch-crl packages
-#  that use a cron based package and not a systemd timer.
-#
 # @param randomcron
 #  Should the every 6 hour cron be configured with a random offset.
 #  With osfamily RedHat 8 or newer the randomcron parameter is ignored.
@@ -111,18 +106,10 @@ class fetchcrl (
   Integer $parallelism                     = 4,
   Enum['direct','qualified', 'cache','syslog'] $logmode = 'syslog',
   String[1] $pkgname                       = 'fetch-crl',
-  Boolean $runboot                         = false,
   Boolean $runcron                         = true,
   Optional[Integer] $cache_control_request = undef,
   Optional[Hash] $cas                      = undef,
 ) {
-  # Is the package cron or systemd.timer based?
-  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'7') <= 0 {
-    $periodic_method = 'cron'
-  } else {
-    $periodic_method = 'timer'
-  }
-
   contain 'fetchcrl::install'
   contain 'fetchcrl::config'
   contain 'fetchcrl::service'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,32 +5,12 @@
 #
 class fetchcrl::service (
   String[1] $pkgname = $fetchcrl::pkgname,
-  Boolean $runboot   = $fetchcrl::runboot,
   Boolean $runcron   = $fetchcrl::runcron,
 ) {
   assert_private()
 
-  case $fetchcrl::periodic_method {
-    'cron': {
-      service { "${pkgname}-boot":
-        ensure     => $runboot,
-        enable     => $runboot,
-        hasstatus  => true,
-        hasrestart => true,
-      }
-      service { "${pkgname}-cron":
-        ensure     => $runcron,
-        enable     => $runcron,
-        hasstatus  => true,
-        hasrestart => true,
-      }
-    }
-    'timer': {
-      service { "${pkgname}.timer":
-        ensure => $runcron,
-        enable => $runcron,
-      }
-    }
-    default: { fail('periodic_method not cron or timer?') }
+  service { "${pkgname}.timer":
+    ensure => $runcron,
+    enable => $runcron,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04"
       ]
     },
@@ -72,15 +71,12 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]

--- a/spec/acceptance/fetchcrl_spec.rb
+++ b/spec/acceptance/fetchcrl_spec.rb
@@ -16,15 +16,6 @@ describe 'fetchcrl' do
       shell('fetch-crl', acceptable_exit_codes: [0, 1])
       shell('ls /etc/grid-security/certificates/*.r0', acceptable_exit_codes: 0)
     end
-
-    describe file('/etc/cron.d/fetch-crl') do
-      case [fact('os.name'), fact('os.release.major')]
-      when %w[CentOS 7], ['Ubuntu', '18.04'], %w[Debian 10]
-        its(:content) { is_expected.to match %r{^([0-9]|[1-5][0-9]) [0-5]-23/6 \* \* \*.*$} }
-      else
-        it { is_expected.not_to exist }
-      end
-    end
   end
 
   context 'with fetchcrl and ipv6 and cas' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -43,21 +43,12 @@ describe 'fetchcrl', type: 'class' do
 
           it { is_expected.not_to contain_apt__source('carepo') }
         end
-        case [facts[:os]['name'], facts[:os]['release']['major']]
-        when %w[RedHat 7], %w[CentOS 7], %w[Debian 10], ['Ubuntu', '18.04']
-          it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
-          it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
-          it { is_expected.to contain_service('fetch-crl-boot').with_ensure(false) }
-          it { is_expected.to contain_service('fetch-crl-boot').with_enable(false) }
-          it { is_expected.to contain_service('fetch-crl-cron').with_ensure(true) }
-          it { is_expected.to contain_service('fetch-crl-cron').with_enable(true) }
-        else
-          it { is_expected.not_to contain_augeas('randomise_cron') }
-          it { is_expected.not_to contain_service('fetch-crl-boot') }
-          it { is_expected.not_to contain_service('fetch-crl-cron') }
-          it { is_expected.to contain_service('fetch-crl.timer').with_ensure(true) }
-          it { is_expected.to contain_service('fetch-crl.timer').with_enable(true) }
-        end
+
+        it { is_expected.not_to contain_augeas('randomise_cron') }
+        it { is_expected.not_to contain_service('fetch-crl-boot') }
+        it { is_expected.not_to contain_service('fetch-crl-cron') }
+        it { is_expected.to contain_service('fetch-crl.timer').with_ensure(true) }
+        it { is_expected.to contain_service('fetch-crl.timer').with_enable(true) }
       end
 
       context 'with all parameters set' do
@@ -112,7 +103,6 @@ describe 'fetchcrl', type: 'class' do
             noerrors: true,
             randomcron: true,
             runcron: true,
-            runboot: true,
             manage_carepo: true,
             inet6glue: true,
           }
@@ -126,7 +116,7 @@ describe 'fetchcrl', type: 'class' do
           it { is_expected.to contain_yumrepo('carepo') }
 
           case facts[:os]['release']['major']
-          when '7', '8'
+          when '8'
             it { is_expected.to contain_package('perl-Net-INET6Glue').with_ensure('present') }
           else
             it { is_expected.not_to contain_package('perl-Net-INET6Glue') }
@@ -135,26 +125,15 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^noerrors$}) }
 
         case [facts[:os]['name'], facts[:os]['release']['major']]
-        when %w[RedHat 7], %w[CentOS 7], %w[RedHat 8], %w[CentOS 8], %w[AlmaLinux 8], %w[OracleLinux 8], %w[Rocky 8], %w[Debian 10], %w[Debian 11], ['Ubuntu', '18.04'], ['Ubuntu', '20.04'], ['Ubuntu', '22.04']
+        when %w[RedHat 8], %w[AlmaLinux 8], %w[OracleLinux 8], %w[Rocky 8], %w[Debian 11], ['Ubuntu', '22.04']
           it { is_expected.to contain_file('/etc/fetch-crl.conf').with_content(%r{^inet6glue$}) }
         else
           it { is_expected.not_to contain_file('/etc/fetch-crl.conf').with_content(%r{^inet6glue$}) }
         end
 
-        case [facts[:os]['name'], facts[:os]['release']['major']]
-        when %w[RedHat 7], %w[CentOS 7], %w[Debian 10], ['Ubuntu', '18.04']
-          it { is_expected.to contain_augeas('randomise_cron').with_incl('/etc/cron.d/fetch-crl') }
-          it { is_expected.to contain_augeas('randomise_cron').with_changes([%r{set minute ([0-9]|[1-5][0-9])}, %r{set hour [0-5]-23/6}]) }
-          it { is_expected.to contain_service('fetch-crl-boot').with_ensure(true) }
-          it { is_expected.to contain_service('fetch-crl-boot').with_enable(true) }
-          it { is_expected.to contain_service('fetch-crl-cron').with_ensure(true) }
-          it { is_expected.to contain_service('fetch-crl-cron').with_enable(true) }
-          it { is_expected.not_to contain_service('fetch-crl.timer') }
-        else
-          it { is_expected.not_to contain_augeas('randomise_cron') }
-          it { is_expected.to contain_service('fetch-crl.timer').with_ensure(true) }
-          it { is_expected.to contain_service('fetch-crl.timer').with_enable(true) }
-        end
+        it { is_expected.not_to contain_augeas('randomise_cron') }
+        it { is_expected.to contain_service('fetch-crl.timer').with_ensure(true) }
+        it { is_expected.to contain_service('fetch-crl.timer').with_enable(true) }
       end
 
       context 'with boolean params parameters set false' do
@@ -163,7 +142,6 @@ describe 'fetchcrl', type: 'class' do
             noerrors: false,
             randomcron: false,
             runcron: false,
-            runboot: false,
             manage_carepo: false,
           }
         end
@@ -173,13 +151,8 @@ describe 'fetchcrl', type: 'class' do
         it { is_expected.to contain_file('/etc/fetch-crl.conf').without_content(%r{^noerrors$}) }
         it { is_expected.not_to contain_augeas('randomise_cron') }
 
-        case [facts[:os]['name'], facts[:os]['release']['major']]
-        when %w[RedHat 7], %w[CentOS 7], %w[Debian 10], ['Ubuntu', '18.04']
-          it { is_expected.not_to contain_service('fetch-crl.timer') }
-        else
-          it { is_expected.to contain_service('fetch-crl.timer').with_ensure(false) }
-          it { is_expected.to contain_service('fetch-crl.timer').with_enable(false) }
-        end
+        it { is_expected.to contain_service('fetch-crl.timer').with_ensure(false) }
+        it { is_expected.to contain_service('fetch-crl.timer').with_enable(false) }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

Drop support for EOL Ubuntu 20.04, CentOS 7, 8 and RHEL 7

With this support for all the OSes still using cron rather than a systemd timer have gone.

With this the `runboot` parameter is removed as obsolete.
